### PR TITLE
Add LinkedIn link to menubar

### DIFF
--- a/src/site/menu.pug
+++ b/src/site/menu.pug
@@ -5,5 +5,7 @@
     .right
         a.menu-item.icon-button(href='https://github.com/MateyByrd')
             i(data-feather='github')
+        a.menu-item.icon-button(href='https://www.linkedin.com/in/nick-belzer-103018130/')
+            i(data-feather='linkedin')
         a.menu-item.icon-button(href='#', id='darkModeToggle')
             i(data-feather='sun')


### PR DESCRIPTION
Resolves #5

- Adds a LinkedIn icon from the feather icon set to the menubar with a link to my personal profile.